### PR TITLE
Fix food spoiling on the first day of spring

### DIFF
--- a/src/main/java/net/spoiledz/util/SpoiledUtil.java
+++ b/src/main/java/net/spoiledz/util/SpoiledUtil.java
@@ -126,7 +126,13 @@ public class SpoiledUtil {
                 seasonsPassed += yearDiff * 4;
                 seasonsPassed += (currentSeasonIndex - oldSeasonIndex + 4) % 4;
             } else if (yearDiff == 0) {
-                seasonsPassed = (currentSeasonIndex - oldSeasonIndex + 4) % 4;
+                int diff = currentSeasonIndex - oldSeasonIndex;
+                // Negative means the stored season hasn't been reached yet in this year.
+                if (diff < 0) {
+                    seasonsPassed = 0;
+                } else {
+                    seasonsPassed = diff;
+                }
             }
         }
         return seasonsPassed;


### PR DESCRIPTION
There is a bug where all the food spoils simultaneously each year, since the calculation considered it a year old, even if it was harvested on the last day of winter.